### PR TITLE
Comment Paging 추가 (Board)

### DIFF
--- a/src/main/java/com/Project/BackEnd/Comment/Controller/CommentController.java
+++ b/src/main/java/com/Project/BackEnd/Comment/Controller/CommentController.java
@@ -103,9 +103,9 @@ public class CommentController {
     /*
     *** 페이징 컨트롤러
      */
-    @GetMapping("/list?page={page}")
-    public ResponseEntity<Page<CommentInfoDTO>> getCommentList(@PathVariable int page){
-        Page<CommentInfoDTO> commentList = this.commentService.getCommentList(page);
+    @GetMapping("/list/{boardId}?page={page}")
+    public ResponseEntity<Page<CommentInfoDTO>> getCommentList(@PathVariable Long boardId, @PathVariable int page){
+        Page<CommentInfoDTO> commentList = this.commentService.getCommentList(boardId, page);
         return ResponseEntity.ok(commentList);
     }
 }

--- a/src/main/java/com/Project/BackEnd/Comment/Controller/CommentController.java
+++ b/src/main/java/com/Project/BackEnd/Comment/Controller/CommentController.java
@@ -11,6 +11,7 @@ import com.Project.BackEnd.Member.Entity.Member;
 import com.Project.BackEnd.Member.Service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -99,5 +100,12 @@ public class CommentController {
         }
     }
 
-
+    /*
+    *** 페이징 컨트롤러
+     */
+    @GetMapping("/list?page={page}")
+    public ResponseEntity<Page<CommentInfoDTO>> getCommentList(@PathVariable int page){
+        Page<CommentInfoDTO> commentList = this.commentService.getCommentList(page);
+        return ResponseEntity.ok(commentList);
+    }
 }

--- a/src/main/java/com/Project/BackEnd/Comment/Controller/CommentController.java
+++ b/src/main/java/com/Project/BackEnd/Comment/Controller/CommentController.java
@@ -48,7 +48,7 @@ public class CommentController {
     *** Member 객체로 List 조회
      */
     @GetMapping("/member/{id}")
-    public ResponseEntity<List<CommentDetailDTO>> commentFindByMember(@PathVariable Long id){
+    public ResponseEntity<List<CommentDetailDTO>> commentFindByMember(@PathVariable("id) Long id){
         try {
             List<CommentDetailDTO> comment = this.commentService.getCommentDetail(id);
             return ResponseEntity.ok(comment);
@@ -61,7 +61,7 @@ public class CommentController {
     *** Board 객체로 List 조회
      */
     @GetMapping("/board/{id}")
-    public ResponseEntity<List<CommentInfoDTO>> commentFindByBoard(@PathVariable Long id) {
+    public ResponseEntity<List<CommentInfoDTO>> commentFindByBoard(@PathVariable("id") Long id) {
         try {
             List<CommentInfoDTO> comment = this.commentService.getCommentInfo(id);
             return ResponseEntity.ok(comment);
@@ -104,7 +104,7 @@ public class CommentController {
     *** 페이징 컨트롤러
      */
     @GetMapping("/list/{boardId}?page={page}")
-    public ResponseEntity<Page<CommentInfoDTO>> getCommentList(@PathVariable Long boardId, @PathVariable int page){
+    public ResponseEntity<Page<CommentInfoDTO>> getCommentList(@PathVariable("boardId") Long boardId, @PathVariable("page") Integer page){
         Page<CommentInfoDTO> commentList = this.commentService.getCommentList(boardId, page);
         return ResponseEntity.ok(commentList);
     }

--- a/src/main/java/com/Project/BackEnd/Comment/Repository/CommentRepository.java
+++ b/src/main/java/com/Project/BackEnd/Comment/Repository/CommentRepository.java
@@ -1,10 +1,10 @@
 package com.Project.BackEnd.Comment.Repository;
 
-import com.Project.BackEnd.Board.Entity.Board;
 import com.Project.BackEnd.Comment.DTO.CommentDetailDTO;
 import com.Project.BackEnd.Comment.DTO.CommentInfoDTO;
 import com.Project.BackEnd.Comment.Entity.Comment;
-import com.Project.BackEnd.Member.Entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,4 +24,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "from Comment as c " +
             "where c.board.id = :id")
     List<CommentInfoDTO> findInfoByBoard(@Param("id") Long id);
+
+    @Query("select new com.Project.BackEnd.Comment.DTO.CommentInfoDTO(c.id, c.content, c.member.name, c.createDate, c.modifyDate) " +
+            "from Comment as c left join Board as b on c.board = b")
+    Page<CommentInfoDTO> findAllList(Pageable pageable);
 }

--- a/src/main/java/com/Project/BackEnd/Comment/Repository/CommentRepository.java
+++ b/src/main/java/com/Project/BackEnd/Comment/Repository/CommentRepository.java
@@ -26,6 +26,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<CommentInfoDTO> findInfoByBoard(@Param("id") Long id);
 
     @Query("select new com.Project.BackEnd.Comment.DTO.CommentInfoDTO(c.id, c.content, c.member.name, c.createDate, c.modifyDate) " +
-            "from Comment as c left join Board as b on c.board = b")
-    Page<CommentInfoDTO> findAllList(Pageable pageable);
+            "from Comment as c " +
+            "where c.board.id = :id")
+    Page<CommentInfoDTO> findCommentListByBoard(@Param("id") Long id, Pageable pageable);
 }

--- a/src/main/java/com/Project/BackEnd/Comment/Service/CommentService.java
+++ b/src/main/java/com/Project/BackEnd/Comment/Service/CommentService.java
@@ -10,6 +10,10 @@ import com.Project.BackEnd.Comment.Repository.CommentRepository;
 import com.Project.BackEnd.DataNotFoundException;
 import com.Project.BackEnd.Member.Entity.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 
@@ -22,6 +26,7 @@ import java.util.Optional;
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final int countsPerPage = 19;
 
     // Create 댓글 작성
     public void createComment(String content, Member member, Board board){
@@ -78,5 +83,13 @@ public class CommentService {
     // Delete 댓글 삭제
     public void deleteComment(long commentId){
         this.commentRepository.deleteById(commentId);
+    }
+
+    /*
+    *** 페이징 기능
+     */
+    public Page<CommentInfoDTO> getCommentList(int page){ // 20개씩 페이징
+        Pageable pageable = PageRequest.of(page, this.countsPerPage, Sort.Direction.DESC, "write_date");
+        return this.commentRepository.findAllList(pageable);
     }
 }

--- a/src/main/java/com/Project/BackEnd/Comment/Service/CommentService.java
+++ b/src/main/java/com/Project/BackEnd/Comment/Service/CommentService.java
@@ -88,8 +88,8 @@ public class CommentService {
     /*
     *** 페이징 기능
      */
-    public Page<CommentInfoDTO> getCommentList(int page){ // 20개씩 페이징
+    public Page<CommentInfoDTO> getCommentList(Long boardId, int page){ // 20개씩 페이징
         Pageable pageable = PageRequest.of(page, this.countsPerPage, Sort.Direction.DESC, "write_date");
-        return this.commentRepository.findAllList(pageable);
+        return this.commentRepository.findCommentListByBoard(boardId, pageable);
     }
 }


### PR DESCRIPTION
Comment Paging 기능 추가 (Board만 적용)

**repository 에서 쿼리문 작성 할때 의문!!!**
@Query("select new com.Project.BackEnd.Comment.DTO.CommentInfoDTO(c.id, c.content, c.member.name, c.createDate, c.modifyDate) " +
            "from Comment as c left join Board as b on c.board = b")
    Page<CommentInfoDTO> findAllList(Pageable pageable);

-> 현재 comment에 board가 외래키로 있어서  이렇게 되어 있는데 
**다른 쿼리 보면 board id를 받아와서 where 조건문으로 찾아옴**

1. left join으로 가져와야 하는가?
2. where절로 변경하고 id도 같이 받아와야 하는가?

PS. 프로필 부분에서도 페이징 기능 추가 해야함